### PR TITLE
feat: editorial redesign with light/dark themes, blog, and SEO

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,4 +1,10 @@
 <script lang="ts" setup>
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+  }
+}
+
 const {
   public: { analytics },
 } = useRuntimeConfig();
@@ -10,17 +16,19 @@ useSeoMeta({
   author: 'Konstantinos Paparas',
   ogTitle: 'Konstantinos Paparas (Kelsos) - Privacy-First Open Source Software Engineer',
   ogDescription: 'Software engineer specializing in open-source development with focus on privacy-preserving applications. Frontend Lead at Rotki building tools for financial privacy.',
-  ogImage: '/img/author.jpg',
-  ogImageWidth: 1200,
-  ogImageHeight: 630,
   ogType: 'website',
   ogUrl: 'https://kelsos.net',
   ogSiteName: 'Konstantinos Paparas Portfolio',
   twitterCard: 'summary_large_image',
   twitterTitle: 'Konstantinos Paparas (Kelsos) - Privacy-First Open Source Software Engineer',
   twitterDescription: 'Software engineer specializing in open-source development with focus on privacy-preserving applications. Frontend Lead at Rotki.',
-  twitterImage: '/img/author.jpg',
-  themeColor: '#262626',
+});
+
+// Site-wide default OG image, rendered at build by the Satori template
+// (app/components/OgImage/Site.satori.vue). Pages can override per-route.
+defineOgImageComponent('Site', {
+  title: 'Privacy-First Open Source Software Engineer',
+  description: 'Frontend Lead at Rotki building tools for financial privacy. Vue.js, TypeScript, Kotlin.',
 });
 
 useHead({
@@ -29,9 +37,16 @@ useHead({
     class: 'scroll-mt-4',
   },
   bodyAttrs: {
-    class: 'antialiased font-sans text-neutral-400 bg-neutral-800',
+    class: 'antialiased font-sans text-body bg-bg',
   },
   script: [
+    // No-flash theme: set the `dark` class before paint based on the stored
+    // preference (key `theme`, matching useTheme) or the system setting.
+    {
+      innerHTML:
+        '(function(){try{var s=localStorage.getItem(\'theme\');var m=window.matchMedia(\'(prefers-color-scheme: dark)\').matches;var d=s===\'dark\'||((s===null||s===\'auto\')&&m);document.documentElement.classList.toggle(\'dark\',d);}catch(e){document.documentElement.classList.add(\'dark\');}})();',
+      tagPosition: 'head',
+    },
     {
       src: `https://www.googletagmanager.com/gtag/js?id=${analytics}`,
       type: 'text/javascript',

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,26 +1,106 @@
 @import '@fontsource-variable/inter';
+@import '@fontsource-variable/fraunces';
 @import 'tailwindcss';
 
-/* Make `font-sans` resolve to Inter (Tailwind v4 is CSS-first; the old
-   tailwind.config.ts theme was never loaded without an @config directive). */
-@theme {
-  --font-sans: 'Inter Variable', 'Inter', ui-sans-serif, system-ui, sans-serif;
+/* Class-based dark mode (toggled on <html> by the theme switch + no-flash script). */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ---------------------------------------------------------------------------
+   Semantic design tokens. Warm-tinted neutral foundation with a single ochre
+   accent. Values switch per theme; Tailwind utilities reference them via
+   @theme inline below (bg-bg, text-fg, border-line, text-accent, ...).
+--------------------------------------------------------------------------- */
+:root {
+  --bg: #faf8f4; /* warm paper */
+  --surface: #ffffff;
+  --surface-2: #f3efe8;
+  --fg: #1c1917; /* ink */
+  --body: #44403c;
+  --muted: #78716c;
+  --line: #e7e2da;
+  --accent: #b45309; /* ochre */
+  --accent-hover: #92400e;
 }
 
-/* Smooth scrolling */
+.dark {
+  --bg: #191613; /* warm near-black */
+  --surface: #221e1b;
+  --surface-2: #2a2521;
+  --fg: #f5f2ee;
+  --body: #c4bcb1;
+  --muted: #8a817a;
+  --line: #332e2a;
+  --accent: #e8a33d; /* warm amber */
+  --accent-hover: #f0b75e;
+}
+
+@theme inline {
+  --font-sans: 'Inter Variable', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Fraunces Variable', ui-serif, Georgia, 'Times New Roman', serif;
+
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-fg: var(--fg);
+  --color-body: var(--body);
+  --color-muted: var(--muted);
+  --color-line: var(--line);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+}
+
 @layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  .dark {
+    color-scheme: dark;
+  }
+
   html {
     scroll-behavior: smooth;
   }
+
+  body {
+    background-color: var(--bg);
+    color: var(--body);
+  }
+
+  /* Fraunces optical-size axis: tune for display use. */
+  .font-display {
+    font-optical-sizing: auto;
+    font-variation-settings:
+      'opsz' 144,
+      'SOFT' 0,
+      'WONK' 0;
+  }
 }
 
-/* Custom animations */
+/* ---------------------------------------------------------------------------
+   Motion: scroll-reveal entrance (applied via the v-reveal directive) and the
+   legacy fade. Both collapse to no-op under prefers-reduced-motion.
+--------------------------------------------------------------------------- */
 @layer utilities {
+  .reveal-init {
+    opacity: 0;
+    transform: translateY(12px);
+    transition:
+      opacity 0.6s ease-out,
+      transform 0.6s ease-out;
+  }
+
+  .reveal-in {
+    opacity: 1;
+    transform: none;
+  }
+
   @keyframes fadeIn {
     from {
       opacity: 0;
       transform: translateY(4px);
     }
+
     to {
       opacity: 1;
       transform: translateY(0);
@@ -29,5 +109,21 @@
 
   .animate-fadeIn {
     animation: fadeIn 0.6s ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reveal-init {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+
+    .animate-fadeIn {
+      animation: none;
+    }
+
+    html {
+      scroll-behavior: auto;
+    }
   }
 }

--- a/app/components/Avatar.vue
+++ b/app/components/Avatar.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
-defineProps<{ img: string }>();
+const { alt = '' } = defineProps<{ img: string; alt?: string }>();
 </script>
 
 <template>
   <div
-    class="relative z-10 flex items-center justify-center w-12 h-12 rounded-full shadow-md shadow-neutral-700/5 bg-neutral-700 ring-1 ring-neutral-600"
+    class="relative z-10 flex items-center justify-center w-12 h-12 rounded-full shadow-sm bg-surface-2 ring-1 ring-line"
   >
     <NuxtImg
       class="w-10 h-10 rounded-full object-cover"
       loading="lazy"
       decoding="async"
       :src="img"
-      alt="Avatar"
+      :alt="alt"
       width="40"
       height="40"
     />

--- a/app/components/Footer.vue
+++ b/app/components/Footer.vue
@@ -6,11 +6,11 @@ const {
 </script>
 
 <template>
-  <footer class="border-t border-neutral-600">
+  <footer class="border-t border-line">
     <div
-      class="max-w-6xl mx-auto px-4 py-8 flex items-center justify-between sm:px-6 lg:px-8"
+      class="max-w-5xl mx-auto px-6 py-8 flex items-center justify-between"
     >
-      <p class="text-sm text-neutral-500">
+      <p class="text-sm text-muted">
         &copy; {{ year }} Konstantinos Paparas
       </p>
       <nav
@@ -23,7 +23,7 @@ const {
           target="_blank"
           rel="noreferrer nofollow"
           aria-label="Bluesky"
-          class="text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="simple-icons:bluesky"
@@ -36,7 +36,7 @@ const {
           target="_blank"
           rel="noreferrer nofollow"
           aria-label="GitHub"
-          class="text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="simple-icons:github"
@@ -49,7 +49,7 @@ const {
           target="_blank"
           rel="noreferrer nofollow"
           aria-label="LinkedIn"
-          class="text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="simple-icons:linkedin"
@@ -62,7 +62,7 @@ const {
           target="_blank"
           rel="noreferrer nofollow"
           aria-label="Keybase"
-          class="text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="simple-icons:keybase"
@@ -73,7 +73,7 @@ const {
           v-if="email"
           :href="email"
           aria-label="Email"
-          class="text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="heroicons:envelope"

--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -1,24 +1,44 @@
 <script setup lang="ts">
+const route = useRoute();
 const isDialogOpen = ref(false);
-const activeSection = ref('profile');
 
-const links = computed(() => [
+// On the blog the in-page sections don't exist, so highlight the Blog link
+// instead of leaving the scroll spy stuck on its initial value.
+const isBlog = computed(() => route.path.startsWith('/blog'));
+const activeSection = ref(route.path.startsWith('/blog') ? 'blog' : 'profile');
+
+const links = [
   { label: 'Profile', to: '#profile', id: 'profile' },
   { label: 'Experience', to: '#timeline', id: 'timeline' },
   { label: 'Selected Work', to: '#projects', id: 'projects' },
   { label: 'Expertise', to: '#skills', id: 'skills' },
   { label: 'Blog', to: '/blog', id: 'blog' },
-]);
+];
 
 // Scroll spy functionality
 function updateActiveSection() {
   if (!import.meta.client)
     return;
 
+  // Off the homepage there are no section anchors to spy on.
+  if (isBlog.value) {
+    activeSection.value = 'blog';
+    return;
+  }
+
   const sections = ['profile', 'timeline', 'projects', 'skills'];
+
+  // The last section can be shorter than the viewport, so its top never passes
+  // the threshold — treat "scrolled to the bottom" as the last section active.
+  const atBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+  if (atBottom) {
+    activeSection.value = sections.at(-1)!;
+    return;
+  }
+
   const scrollPosition = window.scrollY + 100; // Offset for header height
 
-  for (const section of sections.reverse()) {
+  for (const section of [...sections].reverse()) {
     const element = document.getElementById(section);
     if (element && element.offsetTop <= scrollPosition) {
       activeSection.value = section;
@@ -27,52 +47,32 @@ function updateActiveSection() {
   }
 }
 
-onMounted(() => {
-  if (import.meta.client) {
-    window.addEventListener('scroll', updateActiveSection);
-    updateActiveSection(); // Set initial state
-  }
-});
+// useEventListener auto-removes on unmount and is a no-op during SSR; throttle
+// keeps the scroll spy from running on every scroll frame.
+useEventListener('scroll', useThrottleFn(updateActiveSection, 100), { passive: true });
+watch(() => route.path, updateActiveSection);
+onMounted(updateActiveSection); // initial state once the DOM is ready
 
-onUnmounted(() => {
-  if (import.meta.client) {
-    window.removeEventListener('scroll', updateActiveSection);
-  }
-});
-
-// Handle escape key
-function handleEscape(event: KeyboardEvent) {
-  if (event.key === 'Escape' && isDialogOpen.value) {
+// Close the mobile menu on Escape and lock body scroll while it's open.
+onKeyStroke('Escape', () => {
+  if (isDialogOpen.value)
     isDialogOpen.value = false;
-  }
-}
-
-// Lock/unlock body scroll
-watch(isDialogOpen, (newValue) => {
-  if (import.meta.client) {
-    if (newValue) {
-      document.body.style.overflow = 'hidden';
-      document.addEventListener('keydown', handleEscape);
-    }
-    else {
-      document.body.style.overflow = '';
-      document.removeEventListener('keydown', handleEscape);
-    }
-  }
 });
 
-// Cleanup on unmount
+watch(isDialogOpen, (open) => {
+  if (import.meta.client)
+    document.body.style.overflow = open ? 'hidden' : '';
+});
+
 onUnmounted(() => {
-  if (import.meta.client) {
+  if (import.meta.client)
     document.body.style.overflow = '';
-    document.removeEventListener('keydown', handleEscape);
-  }
 });
 </script>
 
 <template>
   <header
-    class="sticky top-0 z-50 w-full backdrop-blur flex-none border-b border-neutral-600 bg-neutral-800/75"
+    class="sticky top-0 z-50 w-full backdrop-blur flex-none border-b border-line bg-bg/75"
   >
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <HeaderLinks
@@ -92,7 +92,7 @@ onUnmounted(() => {
     >
       <div
         v-show="isDialogOpen"
-        class="fixed inset-0 z-50 bg-neutral-800 lg:hidden"
+        class="fixed inset-0 z-50 bg-bg lg:hidden"
         @click="isDialogOpen = false"
       >
         <div
@@ -100,7 +100,7 @@ onUnmounted(() => {
           @click.stop
         >
           <div
-            class="px-4 sm:px-6 border-b border-neutral-600 bg-neutral-800"
+            class="px-4 sm:px-6 border-b border-line bg-bg"
           >
             <HeaderLinks
               v-model="isDialogOpen"

--- a/app/components/HeaderLinks.vue
+++ b/app/components/HeaderLinks.vue
@@ -19,7 +19,7 @@ const {
       <NuxtLink
         to="/"
         aria-label="Home"
-        class="flex items-end gap-1.5 font-bold text-xl text-neutral-100"
+        class="flex items-end gap-1.5 font-bold text-xl text-fg"
       >
         <NuxtImg
           src="/apple-touch-icon.png"
@@ -43,7 +43,7 @@ const {
       </nav>
 
       <div
-        class="flex items-center lg:gap-1.5 lg:border-l lg:border-l-neutral-600 pl-1.5"
+        class="flex items-center lg:gap-1.5 lg:border-l lg:border-l-line pl-1.5"
       >
         <NuxtLink
           v-if="bluesky"
@@ -51,7 +51,7 @@ const {
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Bluesky"
-          class="p-2 text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="p-2 text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="simple-icons:bluesky"
@@ -65,7 +65,7 @@ const {
           target="_blank"
           rel="noopener noreferrer"
           aria-label="GitHub"
-          class="p-2 text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="p-2 text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="simple-icons:github"
@@ -77,7 +77,7 @@ const {
           v-if="email"
           :to="email"
           aria-label="Email"
-          class="p-2 text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="p-2 text-muted hover:text-fg transition-colors duration-200"
         >
           <Icon
             name="heroicons:envelope"
@@ -85,9 +85,11 @@ const {
           />
         </NuxtLink>
 
+        <ThemeToggle />
+
         <button
           type="button"
-          class="lg:hidden p-2 text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+          class="lg:hidden p-2 text-muted hover:text-fg transition-colors duration-200"
           aria-label="Toggle menu"
           :aria-expanded="isDialogOpen"
           @click="isDialogOpen = !isDialogOpen"

--- a/app/components/NavigationLinks.vue
+++ b/app/components/NavigationLinks.vue
@@ -33,11 +33,11 @@ function isActive(link: { to: string; id?: string }) {
   >
     <NuxtLink
       :to="getLink(link.to)"
-      class="block py-3 lg:py-0 lg:inline-flex lg:items-end lg:gap-1.5 text-sm font-medium transition-colors duration-200 border-b border-neutral-600 lg:border-none last:border-b-0"
+      class="block py-3 lg:py-0 lg:inline-flex lg:items-end lg:gap-1.5 text-sm font-medium transition-colors duration-200 border-b border-line lg:border-none last:border-b-0"
       :class="[
         isActive(link)
-          ? 'text-neutral-100'
-          : 'text-neutral-500 hover:text-neutral-300',
+          ? 'text-accent'
+          : 'text-muted hover:text-fg',
       ]"
       @click="emit('click')"
     >

--- a/app/components/OgImage/Site.satori.vue
+++ b/app/components/OgImage/Site.satori.vue
@@ -10,15 +10,20 @@ const { title, description } = defineProps<{
     class="flex h-full w-full flex-col justify-between bg-neutral-800 p-16"
   >
     <!-- Header -->
-    <div class="flex items-center gap-4">
-      <div class="h-16 w-16 rounded-full bg-neutral-600" />
-      <div>
-        <h1 class="text-2xl font-bold text-white">
+    <div class="flex items-center gap-5">
+      <img
+        src="/img/author.jpg"
+        width="80"
+        height="80"
+        class="h-20 w-20 rounded-full object-cover"
+      />
+      <div class="flex flex-col leading-tight">
+        <span class="text-3xl font-bold text-white leading-tight">
           Konstantinos Paparas
-        </h1>
-        <p class="text-lg text-neutral-400">
+        </span>
+        <span class="text-xl text-neutral-400 leading-tight">
           kelsos.net
-        </p>
+        </span>
       </div>
     </div>
 

--- a/app/components/ScrollProgress.vue
+++ b/app/components/ScrollProgress.vue
@@ -1,24 +1,27 @@
 <script setup lang="ts">
-import { useWindowScroll } from '@vueuse/core';
+import { useWindowScroll, useWindowSize } from '@vueuse/core';
 
 const { y } = useWindowScroll();
+// height is a reactive dependency so the bar recalculates on resize, not only scroll.
+const { height: windowHeight } = useWindowSize();
 
 const scrollProgress = computed(() => {
-  if (import.meta.client) {
-    const windowHeight = window.innerHeight;
-    const documentHeight = document.documentElement.scrollHeight;
-    const scrollableHeight = documentHeight - windowHeight;
-    const progress = (y.value / scrollableHeight) * 100;
-    return Math.min(100, Math.max(0, progress));
-  }
-  return 0;
+  if (!import.meta.client)
+    return 0;
+
+  const scrollableHeight = document.documentElement.scrollHeight - windowHeight.value;
+  if (scrollableHeight <= 0)
+    return 0;
+
+  const progress = (y.value / scrollableHeight) * 100;
+  return Math.min(100, Math.max(0, progress));
 });
 </script>
 
 <template>
   <div class="fixed top-0 left-0 w-full h-px z-[60]">
     <div
-      class="h-full bg-slate-500 transition-all duration-300 ease-out"
+      class="h-full bg-accent transition-all duration-300 ease-out"
       :style="{ width: `${scrollProgress}%` }"
     />
   </div>

--- a/app/components/SectionHeader.vue
+++ b/app/components/SectionHeader.vue
@@ -1,19 +1,33 @@
+<script setup lang="ts">
+defineProps<{
+  eyebrow?: string;
+}>();
+
+defineSlots<{
+  default?: () => unknown;
+  title: () => unknown;
+}>();
+</script>
+
 <template>
-  <div class="max-w-6xl px-4 py-4 mx-auto lg:py-8 md:px-6">
-    <div class="max-w-xl mx-auto">
-      <div class="text-center">
-        <h2 class="text-3xl md:text-4xl font-light tracking-tight text-neutral-100 animate-fadeIn">
-          <slot name="title" />
-        </h2>
-      </div>
-    </div>
+  <div class="max-w-2xl">
     <div
-      v-if="$slots.default"
-      class="max-w-xl mx-auto mt-4"
+      v-if="eyebrow"
+      class="flex items-center gap-3"
     >
-      <div class="text-center text-base leading-relaxed text-neutral-400">
-        <slot />
-      </div>
+      <span class="h-px w-8 bg-accent" />
+      <span class="text-xs font-medium uppercase tracking-widest text-muted">
+        {{ eyebrow }}
+      </span>
     </div>
+    <h2 class="mt-4 font-display text-3xl md:text-4xl font-medium tracking-tight text-fg">
+      <slot name="title" />
+    </h2>
+    <p
+      v-if="$slots.default"
+      class="mt-4 text-base leading-relaxed text-body"
+    >
+      <slot />
+    </p>
   </div>
 </template>

--- a/app/components/TechBadge.vue
+++ b/app/components/TechBadge.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
   <span
-    class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border border-neutral-600 bg-neutral-700 text-neutral-400 transition-colors duration-200"
+    class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border border-line bg-surface-2 text-muted transition-colors duration-200"
   >
     {{ tech }}
   </span>

--- a/app/components/ThemeToggle.vue
+++ b/app/components/ThemeToggle.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const { toggleTheme } = useTheme();
+</script>
+
+<template>
+  <!--
+    Prerender-friendly: no reactive state in the rendered markup, so SSR and the
+    client agree (no hydration mismatch) and the button ships in the static HTML.
+    Both icons are always present; the `.dark` class on <html> (set before paint
+    by the no-flash script in app.vue) drives which one shows via the `dark:`
+    Tailwind variant — so the correct icon is visible from first paint.
+  -->
+  <button
+    type="button"
+    class="p-2 text-muted hover:text-fg transition-colors duration-200"
+    aria-label="Toggle color theme"
+    @click="toggleTheme()"
+  >
+    <!-- Visibility classes live on the wrapping span: @nuxt/icon's `.iconify`
+         base rule sets `display`, which would override `hidden` on the Icon. -->
+    <span class="block dark:hidden">
+      <Icon
+        name="heroicons:moon"
+        class="w-5 h-5"
+      />
+    </span>
+    <span class="hidden dark:block">
+      <Icon
+        name="heroicons:sun"
+        class="w-5 h-5"
+      />
+    </span>
+  </button>
+</template>

--- a/app/components/blog/Post.vue
+++ b/app/components/blog/Post.vue
@@ -1,59 +1,60 @@
 <script setup lang="ts">
-import PostTime from '~/components/blog/PostTime.vue';
-
-defineProps<{
+const { date } = defineProps<{
   title: string;
   description: string;
   link: string;
-  date: string;
+  date: string | Date;
   tags: string[];
 }>();
+
+const postDate = computed(() => new Date(date));
+const isoDate = computed(() => postDate.value.toISOString());
+const year = useDateFormat(postDate, 'YYYY');
+const dayMonth = useDateFormat(postDate, 'DD MMM');
 </script>
 
 <template>
-  <article class="relative group py-8 border-b border-neutral-600 last:border-b-0">
-    <NuxtLink
-      :to="link"
-      class="block"
+  <article class="group grid gap-2 py-8 border-b border-line last:border-b-0 md:grid-cols-[8rem_1fr] md:gap-8">
+    <div
+      v-if="date"
+      class="flex items-baseline gap-2 md:flex-col md:gap-0.5 md:pt-1"
     >
-      <div class="flex items-baseline justify-between gap-4 mb-2">
-        <h2 class="text-base font-medium text-neutral-200 group-hover:text-slate-400 transition-colors duration-200">
+      <span class="font-display text-lg font-medium text-fg tabular-nums">
+        {{ year }}
+      </span>
+      <time
+        :datetime="isoDate"
+        class="text-xs uppercase tracking-widest text-muted tabular-nums"
+      >
+        {{ dayMonth }}
+      </time>
+    </div>
+
+    <div>
+      <NuxtLink
+        :to="link"
+        class="block"
+      >
+        <h2 class="font-display text-xl font-medium text-fg group-hover:text-accent transition-colors duration-200">
           {{ title }}
         </h2>
-        <span class="text-xs text-neutral-500 tabular-nums shrink-0">
-          <PostTime
-            v-if="date"
-            :date="date"
-          />
-        </span>
-      </div>
+        <p class="mt-2 text-sm leading-relaxed text-body">
+          {{ description }}
+        </p>
+      </NuxtLink>
 
-      <p class="text-sm leading-relaxed text-neutral-400 mb-3">
-        {{ description }}
-      </p>
-
-      <div class="flex items-center gap-3">
-        <div
-          v-if="tags && tags.length > 0"
-          class="flex flex-wrap gap-1.5"
+      <div
+        v-if="tags && tags.length > 0"
+        class="mt-3 flex flex-wrap gap-1.5"
+      >
+        <span
+          v-for="tag in tags"
+          :key="tag"
+          class="text-xs text-muted"
         >
-          <span
-            v-for="tag in tags"
-            :key="tag"
-            class="text-xs text-neutral-500"
-          >
-            #{{ tag }}
-          </span>
-        </div>
-
-        <span class="ml-auto text-xs font-medium text-slate-400 group-hover:text-slate-300 transition-colors duration-200 flex items-center gap-1">
-          Read more
-          <Icon
-            name="heroicons:arrow-right"
-            class="w-3 h-3"
-          />
+          #{{ tag }}
         </span>
       </div>
-    </NuxtLink>
+    </div>
   </article>
 </template>

--- a/app/components/blog/Posts.vue
+++ b/app/components/blog/Posts.vue
@@ -3,24 +3,30 @@ const { data } = await useAsyncData('blog', () => queryCollection('blog').order(
 </script>
 
 <template>
-  <div class="max-w-3xl mx-auto px-4 sm:px-6">
-    <div class="text-center mb-12">
-      <h1 class="text-3xl md:text-4xl font-light tracking-tight text-neutral-100">
+  <div class="max-w-3xl mx-auto px-6">
+    <div class="mb-12">
+      <div class="flex items-center gap-3">
+        <span class="h-px w-8 bg-accent" />
+        <span class="text-xs font-medium uppercase tracking-widest text-muted">
+          Writing
+        </span>
+      </div>
+      <h1 class="mt-4 font-display text-4xl md:text-5xl font-medium tracking-tight text-fg">
         Latest Posts
       </h1>
-      <p class="mt-4 text-base leading-relaxed text-neutral-400">
-        Here you can find a list of the latest news, updates and articles.
+      <p class="mt-4 text-base leading-relaxed text-body">
+        News, updates and the occasional article.
       </p>
     </div>
 
     <div class="space-y-0">
       <template
         v-for="entry in data"
-        :key="entry._id"
+        :key="entry.path"
       >
         <BlogPost
           :title="entry.title"
-          :date="entry.date.toLocaleString()"
+          :date="entry.date"
           :description="entry.description"
           :tags="entry.tags"
           :link="entry.path"

--- a/app/components/content/ProseA.vue
+++ b/app/components/content/ProseA.vue
@@ -17,7 +17,7 @@ const isExternal = computed<boolean>(() => href.startsWith('http://') || href.st
     :title="title"
     :target="target || '_blank'"
     rel="noopener noreferrer"
-    class="text-slate-400 hover:text-slate-300 transition-colors duration-200"
+    class="text-accent hover:text-accent-hover underline underline-offset-2 transition-colors duration-200"
   >
     <slot />
   </a>
@@ -26,7 +26,7 @@ const isExternal = computed<boolean>(() => href.startsWith('http://') || href.st
     :to="href"
     :title="title"
     :target="target"
-    class="text-slate-400 hover:text-slate-300 transition-colors duration-200"
+    class="text-accent hover:text-accent-hover underline underline-offset-2 transition-colors duration-200"
   >
     <slot />
   </NuxtLink>

--- a/app/components/footer/Link.vue
+++ b/app/components/footer/Link.vue
@@ -14,7 +14,7 @@ defineSlots<{
   <a
     :href="url"
     :aria-label="ariaLabel"
-    class="text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
+    class="text-muted hover:text-fg transition-colors duration-200"
     target="_blank"
   >
     <span class="sr-only">

--- a/app/components/profile/Profile.vue
+++ b/app/components/profile/Profile.vue
@@ -2,46 +2,60 @@
   <main
     id="profile"
     aria-label="Profile"
-    class="flex items-center justify-center min-h-screen w-full"
+    class="w-full border-b border-line"
   >
-    <section class="py-24 w-full">
-      <div class="max-w-2xl mx-auto px-4 text-center animate-fadeIn">
-        <NuxtImg
-          class="w-16 h-16 rounded-full object-cover ring-2 ring-neutral-600 mx-auto"
-          src="/img/author.jpg"
-          alt="Profile picture"
-          width="64"
-          height="64"
-        />
+    <section class="max-w-5xl mx-auto px-6 py-24 md:py-36">
+      <div class="grid items-center gap-12 md:grid-cols-[1fr_auto]">
+        <div class="max-w-2xl animate-fadeIn">
+          <div class="flex items-center gap-3">
+            <span class="h-px w-8 bg-accent" />
+            <p class="text-xs font-medium uppercase tracking-widest text-muted">
+              Software Engineer · Berlin, Germany
+            </p>
+          </div>
 
-        <h1 class="mt-8 text-5xl md:text-7xl font-light tracking-tight text-neutral-100">
-          Konstantinos Paparas
-        </h1>
-
-        <p class="mt-4 text-xs font-medium uppercase tracking-widest text-neutral-500">
-          Software Engineer · Berlin, Germany
-        </p>
-
-        <p class="mt-8 text-base leading-relaxed text-neutral-400 max-w-2xl mx-auto">
-          I'm a software engineer specializing in open-source development with a strong focus on
-          privacy-preserving applications. My expertise spans front-end development with Vue.js and TypeScript,
-          Android development with Kotlin, and full-stack solutions. Currently leading frontend development at Rotki,
-          building tools that empower users to maintain financial privacy while managing their portfolios.
-        </p>
-
-        <div class="mt-8 flex justify-center gap-8">
-          <a
-            href="#projects"
-            class="text-sm font-medium text-slate-400 hover:text-slate-300 transition-colors duration-200"
+          <h1
+            aria-label="Konstantinos Paparas"
+            class="mt-6 font-display text-5xl md:text-7xl font-medium leading-[1.05] tracking-tight text-fg"
           >
-            View My Work &rarr;
-          </a>
-          <a
-            href="#timeline"
-            class="text-sm font-medium text-slate-400 hover:text-slate-300 transition-colors duration-200"
-          >
-            My Journey &rarr;
-          </a>
+            Konstantinos<br />Paparas
+          </h1>
+
+          <p class="mt-8 text-lg leading-relaxed text-body">
+            I build open-source software with a focus on privacy-preserving applications —
+            front-end with Vue.js and TypeScript, Android with Kotlin, and full-stack in between.
+            Currently leading frontend at <span class="text-fg font-medium">Rotki</span>,
+            building tools that keep financial data private.
+          </p>
+
+          <div class="mt-10 flex flex-wrap items-center gap-x-8 gap-y-3">
+            <a
+              href="#projects"
+              class="group inline-flex items-center gap-1.5 text-sm font-medium text-fg border-b border-accent pb-1 transition-colors duration-200 hover:text-accent"
+            >
+              View selected work
+              <Icon
+                name="heroicons:arrow-down-right"
+                class="w-4 h-4 text-accent"
+              />
+            </a>
+            <a
+              href="#timeline"
+              class="text-sm font-medium text-muted hover:text-fg transition-colors duration-200"
+            >
+              My journey &rarr;
+            </a>
+          </div>
+        </div>
+
+        <div class="hidden md:block shrink-0">
+          <NuxtImg
+            class="w-40 h-40 lg:w-48 lg:h-48 rounded-full object-cover ring-1 ring-line shadow-xl"
+            src="/img/author.jpg"
+            alt="Konstantinos Paparas"
+            width="192"
+            height="192"
+          />
         </div>
       </div>
     </section>

--- a/app/components/projects/Entry.vue
+++ b/app/components/projects/Entry.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 import Avatar from '~/components/Avatar.vue';
 
-const { url, img, tech } = defineProps<{
+const { url, img, name, tech } = defineProps<{
   url: string;
   img: string;
+  name: string;
   tech?: string[];
 }>();
 
@@ -14,22 +15,23 @@ defineSlots<{
 </script>
 
 <template>
-  <li class="group flex gap-5 p-5 rounded-lg border border-neutral-600 bg-neutral-700 transition-colors duration-200 hover:border-neutral-500">
+  <li class="group flex gap-5 p-5 rounded-lg border border-line bg-surface transition-colors duration-200 hover:border-accent">
     <Avatar
       :img="img"
+      :alt="`${name} logo`"
       class="shrink-0 mt-0.5"
     />
 
     <div class="flex-1 min-w-0">
       <div class="flex items-center justify-between gap-2">
-        <h3 class="text-base font-medium text-neutral-200 group-hover:text-slate-400 transition-colors duration-200">
+        <h3 class="text-base font-medium text-fg group-hover:text-accent transition-colors duration-200">
           <slot name="title" />
         </h3>
         <a
           :href="url"
           target="_blank"
           rel="noreferrer nofollow"
-          class="text-neutral-500 hover:text-slate-400 transition-colors duration-200 shrink-0"
+          class="text-muted hover:text-accent transition-colors duration-200 shrink-0"
         >
           <Icon
             name="heroicons:arrow-up-right"
@@ -38,7 +40,7 @@ defineSlots<{
         </a>
       </div>
 
-      <p class="mt-1 text-sm leading-relaxed text-neutral-400">
+      <p class="mt-1 text-sm leading-relaxed text-body">
         <slot />
       </p>
 

--- a/app/components/projects/Projects.vue
+++ b/app/components/projects/Projects.vue
@@ -62,56 +62,96 @@ const projects: ProjectDetails[] = [
 const {
   public: { github },
 } = useRuntimeConfig();
+
+const [featured, ...rest] = projects;
 </script>
 
 <template>
   <section
     id="projects"
     aria-label="Selected Work"
-    class="items-center py-16 px-4 min-h-screen"
+    class="max-w-5xl mx-auto px-6 py-20 md:py-28"
   >
-    <SectionHeader>
+    <SectionHeader eyebrow="02 / Selected Work">
       <template #title>
-        Selected Work
+        Things I've shipped
       </template>
-      A curated list of projects I've been involved with
+      A curated selection of projects and contributions.
     </SectionHeader>
-    <div class="max-w-5xl px-4 py-4 mx-auto lg:py-8 md:px-6">
-      <div class="mt-12">
-        <ul
-          role="list"
-          class="grid grid-cols-1 lg:grid-cols-2 gap-6"
-        >
-          <template
-            v-for="project in projects"
-            :key="project.title"
-          >
-            <ProjectEntry
-              :url="project.url"
-              :img="project.image"
-              :tech="project.tech"
-            >
-              <template #title>
-                {{ project.title }}
-              </template>
-              {{ project.description }}
-            </ProjectEntry>
-          </template>
-        </ul>
-      </div>
-      <div class="mt-12 text-center">
-        <p class="text-sm text-neutral-500">
-          For more projects and contributions, visit my
-          <a
-            :href="github"
-            target="_blank"
-            rel="noreferrer nofollow"
-            class="text-slate-400 hover:text-slate-300 transition-colors duration-200 font-medium"
-          >
-            GitHub profile
-          </a>
+
+    <a
+      v-if="featured"
+      v-reveal
+      :href="featured.url"
+      target="_blank"
+      rel="noreferrer nofollow"
+      class="group mt-14 grid gap-6 rounded-xl border border-line bg-surface p-6 transition-colors duration-200 hover:border-accent md:grid-cols-[1fr_1.1fr] md:items-center md:gap-10 md:p-8"
+    >
+      <div class="order-2 md:order-1">
+        <span class="text-xs font-medium uppercase tracking-widest text-accent">
+          Featured
+        </span>
+        <h3 class="mt-3 font-display text-2xl md:text-3xl font-medium text-fg">
+          {{ featured.title }}
+        </h3>
+        <p class="mt-3 text-base leading-relaxed text-body">
+          {{ featured.description }}
         </p>
+        <div class="mt-5 flex flex-wrap gap-2">
+          <TechBadge
+            v-for="techItem in featured.tech"
+            :key="techItem"
+            :tech="techItem"
+          />
+        </div>
+        <span class="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-fg transition-colors duration-200 group-hover:text-accent">
+          Visit project
+          <Icon
+            name="heroicons:arrow-up-right"
+            class="w-4 h-4"
+          />
+        </span>
       </div>
-    </div>
+      <NuxtImg
+        :src="featured.image"
+        :alt="featured.title"
+        class="order-1 w-full rounded-lg border border-line object-cover md:order-2"
+        loading="lazy"
+      />
+    </a>
+
+    <ul
+      role="list"
+      class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2"
+    >
+      <template
+        v-for="project in rest"
+        :key="project.title"
+      >
+        <ProjectEntry
+          :url="project.url"
+          :img="project.image"
+          :name="project.title"
+          :tech="project.tech"
+        >
+          <template #title>
+            {{ project.title }}
+          </template>
+          {{ project.description }}
+        </ProjectEntry>
+      </template>
+    </ul>
+
+    <p class="mt-12 text-sm text-muted">
+      For more projects and contributions, visit my
+      <a
+        :href="github"
+        target="_blank"
+        rel="noreferrer nofollow"
+        class="font-medium text-accent hover:text-accent-hover transition-colors duration-200"
+      >
+        GitHub profile
+      </a>
+    </p>
   </section>
 </template>

--- a/app/components/skills/SkillsCards.vue
+++ b/app/components/skills/SkillsCards.vue
@@ -36,27 +36,30 @@ const skillCategories: SkillCategory[] = [
   <section
     id="skills"
     aria-label="Expertise"
-    class="items-center py-16 px-4 min-h-screen"
+    class="max-w-5xl mx-auto px-6 py-20 md:py-28"
   >
-    <SectionHeader>
+    <SectionHeader eyebrow="03 / Expertise">
       <template #title>
-        Expertise
+        Tools of the trade
       </template>
-      Technologies and tools I've worked with throughout my career
+      Technologies and tools I've worked with throughout my career.
     </SectionHeader>
-    <div class="max-w-3xl px-4 py-4 mx-auto lg:py-8 md:px-6">
-      <div class="mt-12 grid grid-cols-1 md:grid-cols-2 gap-10">
-        <div
-          v-for="category in skillCategories"
-          :key="category.name"
-        >
-          <h3 class="text-xs font-medium uppercase tracking-widest text-neutral-500 mb-3">
-            {{ category.name }}
-          </h3>
-          <p class="text-sm leading-relaxed text-neutral-400">
-            {{ category.skills.join(', ') }}
-          </p>
-        </div>
+
+    <div
+      v-reveal
+      class="mt-14 grid grid-cols-1 gap-x-10 gap-y-10 border-t border-line pt-10 md:grid-cols-2"
+    >
+      <div
+        v-for="category in skillCategories"
+        :key="category.name"
+      >
+        <h3 class="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-widest text-fg">
+          <span class="h-1 w-1 rounded-full bg-accent" />
+          {{ category.name }}
+        </h3>
+        <p class="text-sm leading-relaxed text-body">
+          {{ category.skills.join(' · ') }}
+        </p>
       </div>
     </div>
   </section>

--- a/app/components/text/Description.vue
+++ b/app/components/text/Description.vue
@@ -1,5 +1,0 @@
-<template>
-  <p class="relative z-10 mt-2 text-sm text-neutral-400">
-    <slot />
-  </p>
-</template>

--- a/app/components/text/Title.vue
+++ b/app/components/text/Title.vue
@@ -1,5 +1,0 @@
-<template>
-  <h2 class="text-base font-semibold text-neutral-100">
-    <slot />
-  </h2>
-</template>

--- a/app/components/timeline/Timeline.vue
+++ b/app/components/timeline/Timeline.vue
@@ -64,34 +64,37 @@ const entries: TimelineDataEntry[] = [
   <section
     id="timeline"
     aria-label="Experience"
-    class="items-center py-16 min-h-screen"
+    class="max-w-5xl mx-auto px-6 py-20 md:py-28"
   >
-    <SectionHeader>
+    <SectionHeader eyebrow="01 / Experience">
       <template #title>
-        Experience
+        A decade of building
       </template>
-      My professional journey and experience
+      The roles and teams that shaped how I work.
     </SectionHeader>
-    <div class="max-w-3xl px-4 py-4 mx-auto lg:py-8 md:px-6">
-      <div class="mt-8 space-y-0">
-        <div
-          v-for="(entry, i) in entries"
-          :key="i"
-          class="py-5"
-          :class="{ 'border-b border-neutral-600': i < entries.length - 1 }"
-        >
-          <div class="flex items-baseline justify-between gap-4">
-            <h3 class="text-base font-medium text-neutral-200">
-              {{ entry.where }}
+
+    <div
+      v-reveal
+      class="mt-14 border-t border-line"
+    >
+      <div
+        v-for="(entry, i) in entries"
+        :key="i"
+        class="grid gap-2 py-6 border-b border-line md:grid-cols-[8rem_1fr] md:gap-8"
+      >
+        <span class="text-sm font-medium tabular-nums text-muted md:pt-0.5">
+          {{ entry.period }}
+        </span>
+        <div>
+          <div class="flex flex-wrap items-baseline justify-between gap-x-4">
+            <h3 class="text-base font-medium text-fg">
+              {{ entry.what }}
             </h3>
-            <span class="text-sm text-neutral-500 tabular-nums shrink-0">
-              {{ entry.period }}
+            <span class="text-sm text-accent">
+              {{ entry.where }}
             </span>
           </div>
-          <p class="mt-1 text-sm text-neutral-500">
-            {{ entry.what }}
-          </p>
-          <p class="mt-2 text-sm leading-relaxed text-neutral-400">
+          <p class="mt-2 text-sm leading-relaxed text-body">
             {{ entry.description }}
           </p>
         </div>

--- a/app/composables/use-theme.ts
+++ b/app/composables/use-theme.ts
@@ -1,0 +1,20 @@
+import { useDark, useToggle } from '@vueuse/core';
+
+/**
+ * Light/dark theme state, persisted to localStorage under `theme` and applied
+ * as a `dark` class on <html>. The no-flash inline script in app.vue reads the
+ * same key before paint to avoid a theme flash on first load.
+ */
+export function useTheme() {
+  const isDark = useDark({
+    attribute: 'class',
+    selector: 'html',
+    storageKey: 'theme',
+    valueDark: 'dark',
+    valueLight: '',
+  });
+
+  const toggleTheme = useToggle(isDark);
+
+  return { isDark, toggleTheme };
+}

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { NuxtError } from '#app';
+
+const { error } = defineProps<{ error: NuxtError }>();
+
+const code = computed(() => error?.statusCode ?? 500);
+const isNotFound = computed(() => code.value === 404);
+const heading = computed(() => (isNotFound.value ? 'Page not found' : 'Something went wrong'));
+const message = computed(() =>
+  isNotFound.value
+    ? 'The page you\'re looking for doesn\'t exist or may have moved.'
+    : 'An unexpected error occurred. Please try again in a moment.',
+);
+
+// error.vue renders outside app.vue, so the head essentials (lang, theme class,
+// and the no-flash theme script) have to be re-declared here.
+useHead({
+  htmlAttrs: {
+    lang: 'en',
+    class: 'scroll-mt-4',
+  },
+  bodyAttrs: {
+    class: 'antialiased font-sans text-body bg-bg',
+  },
+  script: [
+    {
+      innerHTML:
+        '(function(){try{var s=localStorage.getItem(\'theme\');var m=window.matchMedia(\'(prefers-color-scheme: dark)\').matches;var d=s===\'dark\'||((s===null||s===\'auto\')&&m);document.documentElement.classList.toggle(\'dark\',d);}catch(e){document.documentElement.classList.add(\'dark\');}})();',
+      tagPosition: 'head',
+    },
+  ],
+});
+
+useSeoMeta({
+  title: () => `${code.value} · ${heading.value}`,
+  robots: 'noindex, follow',
+});
+</script>
+
+<template>
+  <NuxtLayout name="default">
+    <main
+      aria-label="Error"
+      class="max-w-5xl mx-auto px-6 py-28 md:py-40 min-h-[60vh] flex flex-col items-start justify-center"
+    >
+      <div class="flex items-center gap-3">
+        <span class="h-px w-8 bg-accent" />
+        <p class="text-xs font-medium uppercase tracking-widest text-muted">
+          Error {{ code }}
+        </p>
+      </div>
+
+      <p
+        class="mt-6 font-display text-7xl md:text-9xl font-medium leading-none tracking-tight text-fg"
+        aria-hidden="true"
+      >
+        {{ code }}
+      </p>
+
+      <h1 class="mt-6 font-display text-3xl md:text-4xl font-medium tracking-tight text-fg">
+        {{ heading }}
+      </h1>
+
+      <p class="mt-4 max-w-md text-base leading-relaxed text-body">
+        {{ message }}
+      </p>
+
+      <div class="mt-10 flex flex-wrap items-center gap-x-8 gap-y-3">
+        <button
+          type="button"
+          class="group inline-flex items-center gap-1.5 text-sm font-medium text-fg border-b border-accent pb-1 transition-colors duration-200 hover:text-accent"
+          @click="clearError({ redirect: '/' })"
+        >
+          Back home
+          <Icon
+            name="heroicons:arrow-right"
+            class="w-4 h-4 text-accent transition-transform duration-200 group-hover:translate-x-0.5"
+          />
+        </button>
+        <NuxtLink
+          to="/blog"
+          class="text-sm font-medium text-muted hover:text-fg transition-colors duration-200"
+        >
+          Read the blog &rarr;
+        </NuxtLink>
+      </div>
+    </main>
+  </NuxtLayout>
+</template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,14 +1,16 @@
 <template>
-  <div>
+  <div class="flex flex-col min-h-screen">
     <a
       href="#profile"
-      class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[70] focus:px-4 focus:py-2 focus:bg-neutral-700 focus:text-neutral-100 focus:rounded-lg focus:text-sm focus:font-medium"
+      class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[70] focus:px-4 focus:py-2 focus:bg-surface focus:text-fg focus:rounded-lg focus:text-sm focus:font-medium focus:ring-1 focus:ring-line"
     >
       Skip to content
     </a>
     <ScrollProgress />
     <Header />
-    <slot />
+    <div class="flex-1">
+      <slot />
+    </div>
     <Footer />
   </div>
 </template>

--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -4,10 +4,21 @@ definePageMeta({
 });
 
 const route = useRoute();
+const { public: { bluesky } } = useRuntimeConfig();
 
 const { data } = await useAsyncData(route.path, async () => {
-  const post = await queryCollection('blog').path(route.path).first();
-  return post || null;
+  const posts = await queryCollection('blog').order('date', 'DESC').all();
+  const index = posts.findIndex(p => p.path === route.path);
+
+  if (index === -1)
+    return null;
+
+  return {
+    post: posts[index],
+    // Newest first, so a lower index is the more recent post.
+    newer: index > 0 ? posts[index - 1] : null,
+    older: index < posts.length - 1 ? posts[index + 1] : null,
+  };
 });
 
 // Redirect if post not found
@@ -15,40 +26,157 @@ if (!data.value) {
   await navigateTo('/blog');
 }
 
-const postDate = computed(() => data.value?.date);
+const post = computed(() => data.value?.post);
+const newer = computed(() => data.value?.newer);
+const older = computed(() => data.value?.older);
+
+const postDate = computed(() => post.value?.date);
 const formattedDate = useDateFormat(postDate, 'DD MMMM YYYY');
+
+const author = 'Konstantinos Paparas';
+const blueskyHandle = computed(() => `@${bluesky.split('/').pop()}`);
+
+// Content excerpts can contain hard line breaks; collapse whitespace for meta.
+const cleanDescription = computed(() => post.value?.description?.replace(/\s+/g, ' ').trim());
+const publishedTime = computed(() => (post.value?.date ? new Date(post.value.date).toISOString() : undefined));
+
+useSeoMeta({
+  title: () => post.value?.title,
+  description: () => cleanDescription.value,
+  ogTitle: () => post.value?.title,
+  ogDescription: () => cleanDescription.value,
+  ogType: 'article',
+  articlePublishedTime: () => publishedTime.value,
+  articleAuthor: [author],
+});
+
+useSchemaOrg([
+  defineArticle({
+    headline: () => post.value?.title,
+    description: () => cleanDescription.value,
+    datePublished: () => publishedTime.value,
+    image: '/img/author.jpg',
+    // author/publisher auto-link to the site-wide Person identity (nuxt.config schemaOrg)
+  }),
+  defineBreadcrumb({
+    itemListElement: [
+      { name: 'Home', item: '/' },
+      { name: 'Blog', item: '/blog' },
+      { name: () => post.value?.title, item: () => route.path },
+    ],
+  }),
+]);
+
+// OG image props are baked at prerender (not reactive), so reading .value here is intentional.
+// eslint-disable-next-line vue/no-ref-object-reactivity-loss -- prerender-time read
+defineOgImageComponent('Site', { title: post.value?.title, description: cleanDescription.value });
 </script>
 
 <template>
   <main
-    v-if="data"
-    class="max-w-3xl mx-auto px-4 sm:px-6"
+    v-if="post"
+    class="max-w-3xl mx-auto px-6"
   >
     <nav class="mb-8">
-      <button
-        type="button"
-        class="inline-flex items-center gap-1.5 text-sm text-neutral-500 hover:text-neutral-300 transition-colors duration-200"
-        @click="navigateTo('/blog')"
+      <NuxtLink
+        to="/blog"
+        class="group inline-flex items-center gap-1.5 text-sm text-muted hover:text-fg transition-colors duration-200"
       >
         <Icon
           name="heroicons:arrow-left"
-          class="w-4 h-4"
+          class="w-4 h-4 transition-transform duration-200 group-hover:-translate-x-0.5"
         />
         Back to posts
-      </button>
+      </NuxtLink>
     </nav>
 
-    <header class="mb-12">
-      <p class="text-xs font-medium uppercase tracking-widest text-neutral-500 mb-4">
+    <header class="mb-12 border-b border-line pb-8">
+      <p class="text-xs font-medium uppercase tracking-widest text-accent mb-4">
         {{ formattedDate }}
       </p>
-      <h1 class="text-3xl md:text-4xl font-light tracking-tight text-neutral-100">
-        {{ data.title }}
+      <h1 class="font-display text-4xl md:text-5xl font-medium tracking-tight text-fg">
+        {{ post.title }}
       </h1>
+
+      <div class="mt-8 flex items-center gap-3">
+        <NuxtImg
+          class="w-11 h-11 rounded-full object-cover ring-1 ring-line shrink-0"
+          src="/img/author.jpg"
+          :alt="author"
+          width="44"
+          height="44"
+        />
+        <div class="text-sm leading-tight">
+          <p class="font-medium text-fg">
+            {{ author }}
+          </p>
+          <a
+            :href="bluesky"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-muted hover:text-accent transition-colors duration-200"
+          >
+            {{ blueskyHandle }}
+          </a>
+        </div>
+      </div>
+
+      <div
+        v-if="post.tags && post.tags.length > 0"
+        class="mt-6 flex flex-wrap gap-1.5"
+      >
+        <span
+          v-for="tag in post.tags"
+          :key="tag"
+          class="text-xs text-muted"
+        >
+          #{{ tag }}
+        </span>
+      </div>
     </header>
 
-    <article class="prose-editorial [&_p]:py-2 [&_p]:text-neutral-300 [&_p]:text-base [&_p]:leading-relaxed [&_h2]:text-xl [&_h2]:font-medium [&_h2]:text-neutral-200 [&_h2]:mt-10 [&_h2]:mb-4 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-neutral-200 [&_h3]:mt-8 [&_h3]:mb-3 [&_ul]:text-neutral-300 [&_ol]:text-neutral-300 [&_li]:text-neutral-300 [&_blockquote]:border-l-2 [&_blockquote]:border-neutral-600 [&_blockquote]:pl-4 [&_blockquote]:text-neutral-400 [&_blockquote]:italic [&_code]:text-neutral-300 [&_pre]:bg-neutral-700 [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-neutral-600 [&_img]:rounded-lg [&_img]:border [&_img]:border-neutral-600 [&_hr]:border-neutral-600">
-      <ContentRenderer :value="data" />
+    <article class="prose-editorial [&_p]:py-2 [&_p]:text-body [&_p]:text-base [&_p]:leading-relaxed [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-medium [&_h2]:text-fg [&_h2]:mt-10 [&_h2]:mb-4 [&_h3]:text-lg [&_h3]:font-medium [&_h3]:text-fg [&_h3]:mt-8 [&_h3]:mb-3 [&_ul]:text-body [&_ol]:text-body [&_li]:text-body [&_a]:text-accent [&_a]:underline [&_a]:underline-offset-2 [&_blockquote]:border-l-2 [&_blockquote]:border-accent [&_blockquote]:pl-4 [&_blockquote]:text-muted [&_blockquote]:italic [&_code]:text-fg [&_pre]:bg-surface-2 [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-line [&_img]:rounded-lg [&_img]:border [&_img]:border-line [&_hr]:border-line">
+      <ContentRenderer :value="post" />
     </article>
+
+    <nav
+      v-if="older || newer"
+      aria-label="Post navigation"
+      class="mt-16 grid grid-cols-2 gap-4 border-t border-line pt-8"
+    >
+      <NuxtLink
+        v-if="older"
+        :to="older.path"
+        class="group col-start-1 flex flex-col gap-1"
+      >
+        <span class="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-widest text-muted">
+          <Icon
+            name="heroicons:arrow-left"
+            class="w-3.5 h-3.5 transition-transform duration-200 group-hover:-translate-x-0.5"
+          />
+          Older
+        </span>
+        <span class="font-display text-base font-medium text-fg group-hover:text-accent transition-colors duration-200">
+          {{ older.title }}
+        </span>
+      </NuxtLink>
+
+      <NuxtLink
+        v-if="newer"
+        :to="newer.path"
+        class="group col-start-2 flex flex-col items-end gap-1 text-right"
+      >
+        <span class="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-widest text-muted">
+          Newer
+          <Icon
+            name="heroicons:arrow-right"
+            class="w-3.5 h-3.5 transition-transform duration-200 group-hover:translate-x-0.5"
+          />
+        </span>
+        <span class="font-display text-base font-medium text-fg group-hover:text-accent transition-colors duration-200">
+          {{ newer.title }}
+        </span>
+      </NuxtLink>
+    </nav>
   </main>
 </template>

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -2,6 +2,18 @@
 definePageMeta({
   layout: 'blog',
 });
+
+useSeoMeta({
+  title: 'Blog',
+  description: 'News, updates and the occasional article by Konstantinos Paparas.',
+  ogTitle: 'Blog',
+  ogDescription: 'News, updates and the occasional article by Konstantinos Paparas.',
+});
+
+defineOgImageComponent('Site', {
+  title: 'Blog',
+  description: 'News, updates and the occasional article by Konstantinos Paparas.',
+});
 </script>
 
 <template>

--- a/app/plugins/reveal.ts
+++ b/app/plugins/reveal.ts
@@ -1,0 +1,43 @@
+import { useIntersectionObserver } from '@vueuse/core';
+
+/**
+ * `v-reveal` — fades + lifts an element into view the first time it intersects
+ * the viewport, via VueUse's `useIntersectionObserver`. The `mounted` hook only
+ * runs on the client, so SSR/no-JS output stays fully visible; the directive
+ * opts the element into the entrance animation only once mounted. Honors
+ * prefers-reduced-motion via the CSS in main.css.
+ *
+ * Registered universally (not client-only) so SSR can resolve the directive —
+ * `getSSRProps` returns no props (Vue calls it during SSR; an unregistered
+ * directive throws on the missing hook).
+ */
+const stoppers = new WeakMap<HTMLElement, () => void>();
+
+// eslint-disable-next-line import/no-default-export -- Nuxt plugins must default-export
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.directive('reveal', {
+    getSSRProps: () => ({}),
+    mounted(el: HTMLElement) {
+      el.classList.add('reveal-init');
+
+      const { stop } = useIntersectionObserver(
+        el,
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              el.classList.add('reveal-in');
+              stop();
+            }
+          }
+        },
+        { rootMargin: '0px 0px -10% 0px', threshold: 0.1 },
+      );
+
+      stoppers.set(el, stop);
+    },
+    unmounted(el: HTMLElement) {
+      stoppers.get(el)?.();
+      stoppers.delete(el);
+    },
+  });
+});

--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,7 +1,7 @@
 import type { RouterConfig } from '@nuxt/schema';
 
 function findHashPosition(hash: string): {
-  el: any;
+  el: string;
   behavior: ScrollBehavior;
   top: number;
 } | undefined {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,7 +28,13 @@ export default defineNuxtConfig({
       ],
       meta: [
         {
-          content: '#262626',
+          content: '#191613',
+          media: '(prefers-color-scheme: dark)',
+          name: 'theme-color',
+        },
+        {
+          content: '#faf8f4',
+          media: '(prefers-color-scheme: light)',
           name: 'theme-color',
         },
         {
@@ -129,6 +135,23 @@ export default defineNuxtConfig({
       github: 'https://github.com/kelsos',
       keybase: 'https://keybase.io/kelsos',
       linkedin: 'https://gr.linkedin.com/in/kelsos',
+    },
+  },
+
+  schemaOrg: {
+    identity: {
+      description: 'Software engineer specializing in open-source development with focus on privacy-preserving applications. Frontend Lead at Rotki.',
+      image: '/img/author.jpg',
+      jobTitle: 'Software Engineer',
+      name: 'Konstantinos Paparas',
+      sameAs: [
+        'https://github.com/kelsos',
+        'https://gr.linkedin.com/in/kelsos',
+        'https://bsky.app/profile/kelsos.bsky.social',
+        'https://keybase.io/kelsos',
+      ],
+      type: 'Person',
+      url: 'https://kelsos.net',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",
     "@nuxtjs/robots": "6.0.8",
     "@nuxtjs/seo": "5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/fraunces':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -838,6 +841,9 @@ packages:
 
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
+  '@fontsource-variable/fraunces@5.2.9':
+    resolution: {integrity: sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==}
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
@@ -8481,6 +8487,8 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@fontsource-variable/fraunces@5.2.9': {}
 
   '@fontsource-variable/inter@5.2.8': {}
 


### PR DESCRIPTION
## Summary

A full editorial/typographic redesign of the portfolio, a reworked blog, and a comprehensive SEO/metadata pass.

### Design & theming
- **Fraunces** (display) + **Inter** (body); semantic light/dark CSS-var tokens switched by a `.dark` class, with a no-flash inline script (no theme flash on load).
- **Prerendered, hydration-safe theme toggle** — both icons render and CSS (`dark:` variant) picks the right one, so it ships in static HTML with no hydration mismatch.
- Asymmetric hero, **ledger-style experience timeline**, featured + compact projects, left-aligned section headers, and `v-reveal` entrance animations (IntersectionObserver via VueUse, SSR-safe).

### Blog
- **Ledger-style post list** (year / day-month column) mirroring the timeline.
- Article pages: **author byline** (avatar, name, Bluesky handle), **prev/next navigation**, and a `NuxtLink` back-to-posts.

### SEO
- Per-page titles/descriptions; **dynamic 1200×630 Satori OG cards** (per-post titles).
- schema.org: site-wide **Person identity** + **Article** + **BreadcrumbList** (author/publisher auto-linked to the Person `@id`).
- Descriptive image `alt` text; accessible hero `h1` name.

### Misc / fixes
- **Themed error page** (`error.vue`) matching the design; footer pinned to the viewport bottom.
- Route-aware nav active state; **scroll-spy fixed** so the last section (Expertise) highlights at the bottom.
- Modernized `Header` listeners (`useEventListener` / `useThrottleFn` / `onKeyStroke`); `ScrollProgress` recalculates on resize.
- Fixed pre-existing type errors (`window.dataLayer`, blog `entry._id` → `entry.path`).

## Verification
- `pnpm lint` ✅
- `nuxi typecheck` ✅ (0 errors)
- `pnpm generate` ✅ (0 prerender errors, 33 routes)
- Both themes, blog list/article, OG cards, 404, and scroll-spy verified in-browser.